### PR TITLE
Cache test discovery variables so they are accessible elsewhere

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -365,7 +365,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT (hicpp-no-assembler)
 #else
 #include <signal.h>
-#define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
+#define DOCTEST_BREAK_INTO_DEBUGGER() (static_cast<void>(0))
 #endif
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -4288,9 +4288,14 @@ namespace {
             // The following settings are taken from google test, and more
             // specifically from UnitTest::Run() inside of gtest.cc
 
+            // @MarkusR disable error modes if we are not on a desktop platform
+            UINT ErrorMode = 0;
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
             // the user does not want to see pop-up dialogs about crashes
-            prev_error_mode_1 = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT |
-                                             SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+            ErrorMode = SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT |
+                                             SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX;
+#endif
+            prev_error_mode_1 = SetErrorMode(ErrorMode);
             // This forces the abort message to go to stderr in all circumstances.
             prev_error_mode_2 = _set_error_mode(_OUT_TO_STDERR);
             // In the debug version, Visual Studio pops up a separate dialog

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -370,7 +370,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT (hicpp-no-assembler)
 #else
 #include <signal.h>
-#define DOCTEST_BREAK_INTO_DEBUGGER() (static_cast<void>(0))
+#define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
 #endif
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -692,6 +692,9 @@ struct DOCTEST_INTERFACE AssertData
     // for normal asserts
     String m_decomp;
 
+    String m_expected;
+    String m_actual;
+
     // for specific exception-related asserts
     bool        m_threw_as;
     const char* m_exception_type;
@@ -1395,8 +1398,12 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
         DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
                                             const DOCTEST_REF_WRAP(R) rhs) {
             m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if(m_failed || getContextOptions()->success)
+            if(m_failed || getContextOptions()->success) {
                 m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+
+                m_expected = toString(lhs);
+                m_actual = toString(rhs);
+            }
         }
 
         template <typename L>

--- a/scripts/cmake/doctest.cmake
+++ b/scripts/cmake/doctest.cmake
@@ -126,8 +126,8 @@ function(doctest_discover_tests TARGET)
   string(SUBSTRING ${args_hash} 0 7 args_hash)
 
   # Define rule to generate test list for aforementioned test executable
-  set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_include-${args_hash}.cmake")
-  set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_tests-${args_hash}.cmake")
+  set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_include-${args_hash}.cmake" CACHE STRING "")
+  set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_tests-${args_hash}.cmake" CACHE STRING "")
   get_property(crosscompiling_emulator
     TARGET ${TARGET}
     PROPERTY CROSSCOMPILING_EMULATOR
@@ -185,5 +185,5 @@ endfunction()
 ###############################################################################
 
 set(_DOCTEST_DISCOVER_TESTS_SCRIPT
-  ${CMAKE_CURRENT_LIST_DIR}/doctestAddTests.cmake
+  ${CMAKE_CURRENT_LIST_DIR}/doctestAddTests.cmake CACHE STRING "cmake internal tests script"
 )

--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -57,7 +57,7 @@ foreach(line ${output})
   endif()
   set(test ${line})
   set(labels "")
-  if(${add_labels} EQUAL 1)
+  if(${add_labels})
     # get test suite that test belongs to
     execute_process(
       COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites


### PR DESCRIPTION
Ensures that test discovery works regardless of where in the hierarchy it is being requested