### PR TITLE
chore(internal): Flip LHS and RHS in the assert string to match how its used. [GSCPP-1843]

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1401,8 +1401,8 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
             if(m_failed || getContextOptions()->success) {
                 m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
 
-                m_expected = toString(lhs);
-                m_actual = toString(rhs);
+                m_expected = toString(rhs);
+                m_actual = toString(lhs);
             }
         }
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -684,6 +684,9 @@ struct DOCTEST_INTERFACE AssertData
     // for normal asserts
     String m_decomp;
 
+    String m_expected;
+    String m_actual;
+
     // for specific exception-related asserts
     bool        m_threw_as;
     const char* m_exception_type;
@@ -1387,8 +1390,12 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
         DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
                                             const DOCTEST_REF_WRAP(R) rhs) {
             m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if(m_failed || getContextOptions()->success)
-                m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+            if(m_failed || getContextOptions()->success) {
+                m_decomp   = stringifyBinaryExpr(lhs, ", ", rhs);
+
+                m_expected = toString(rhs);
+                m_actual   = toString(lhs);
+            }
         }
 
         template <typename L>


### PR DESCRIPTION
Clickup Ticket: https://app.clickup.com/t/9003015469/GSCPP-1923

Simple change to our comparison assert log to match how it's actually used in our unit tests.