### PR TITLE
chore(internal): increase cmake minimum required version to support cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)


### PR DESCRIPTION
Clickup Ticket: https://app.clickup.com/t/9003015469/GSCPP-2023

CMake 4 has backwards support up to version 3.5, so we need to update this to at least 3.5.
However we are already using 3.20 as our minimum supported version in our main sdk project.
As such I figured, better for us to target the same minimums.